### PR TITLE
Added support for quote mode and fixed a bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Right now this script only supports the following typing modes on MonkeyType:
   
 * *Quote* - To let the script perform a typing test in the _quote_ mode, call the `type_text()` function at the bottom of the file method and start the script. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Quote mode of your desired length.  
   
-*Timed tests, 15, 30, 60 and 120 seconds, are not supported*
+*Timed tests, 15, 30, 60 and 120 seconds, are not supported as this would allow users to cheat the leaderboard*
 
 There are a few options the user can use to modify the execution of the script:  
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Requirements:
 * On Arch based distributions use `sudo pacman -S chromium`  
 * On Ubuntu based distrubutions use `sudo apt-get install chromium-browser`  
 * On other operating systems, go to: https://www.chromium.org/getting-involved/download-chromium
-
+  
+_Make sure to download a Chrome/Chromium version that is compatible with the Chromedriver, you can also replace the Chromedriver with a different version_
 # How to use  
 Right now this script only supports the following typing modes on MonkeyType:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Python-autotyper-script
 Python Script to simulate keyboard key presses using pyautogui.  
-This script is designed for use on the website monkeytype.com
+This script is designed for use on the website monkeytype.com  
+  
+*I do not encourage cheating, this script is just for fun*
 
 Requirements:
 
@@ -26,18 +28,18 @@ Requirements:
 # How to use  
 Right now this script only supports the following typing modes on MonkeyType:
 
-*Custom* - To let the script type a custom text, enter the text you want to type into the MonkeyType interface. Then also enter it into the `text` variable in the script. Finally call the `type_given_text()` method with the `text` variable inside the parentheses. After starting the script, switch to the browser in which the typing test is opened. 
+*Custom* - To let the script perform a typing test in the _custom_ mode, call the `type_text()` and start the script. A new Chrome/Chromium window will now open. A new Chrome/Chromium window will now open. Use the starting delay to change the custom text and start the test.  
   
-*Words* - To let the script perform a typing test in the _words_ mode, simply call the `type_random_text()` and start the script. A new Chrome/Chromium window will now open. In the window you can start a typing test with either 10, 25, 50 or 100 words.  
+*Words* - To let the script perform a typing test in the _words_ mode, call the `type_text()` and start the script. A new Chrome/Chromium window will now open. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Words mode of your desired length.  
   
-*Quote* - Typing quotes are partially supported right now. The script is not yet able to type some characters such as quotations marks. Aside from these symbols the script will perform well.  
+*Quote* - To let the script perform a typing test in the _quote_ mode, call the `type_text()` method and start the script. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Quote mode of your desired length.  
   
 
 There are a few options the user can use to modify the execution of the script:  
 
-* Random typing speed. To randomize typing speed, the user can call the `get_random_pause()` method to randomize the pausing time between each character. This allows for a varying speed and consistency. 
-* Given typing speed. To increase or decrease the time between each typed character, the `get_given_pause()` method can be called. The time between each character is the same when using this method. 
-* Sleep time before execution. When one of the typing methods is called, the program wil pause execution. This is done in order to allow the user to open the desired typing mode on MonkeyType.
+* Random typing speed. To randomize typing speed, the user can call the `get_random_pause()` function to randomize the pausing time between each character. This allows for a varying speed and consistency. 
+* Given typing speed. To increase or decrease the time between each typed character, the `get_given_pause()` function can be called. The time between each character is the same when using this function. 
+* Sleep time before execution. When one of the typing functions is called, the program wil pause execution. This is done in order to allow the user to open the desired typing mode on MonkeyType.
 
 # Demonstrations
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 Python Script to simulate keyboard key presses using pyautogui.  
 This script is designed for use on the website monkeytype.com  
   
-*I do not encourage cheating, this script is just for fun*
-
 Requirements:
 
 * Python  
@@ -29,20 +27,21 @@ _Make sure to download a Chrome/Chromium version that is compatible with the Chr
 # How to use  
 Right now this script only supports the following typing modes on MonkeyType:
 
-*Custom* - To let the script perform a typing test in the _custom_ mode, call the `type_text()` and start the script. A new Chrome/Chromium window will now open. A new Chrome/Chromium window will now open. Use the starting delay to change the custom text and start the test.  
+* *Custom* - To let the script perform a typing test in the _custom_ mode, call the `type_text()` function at the bottom of the file and start the script. A new Chrome/Chromium window will now open. A new Chrome/Chromium window will now open. Use the starting delay to change the custom text and start the test.  
   
-*Words* - To let the script perform a typing test in the _words_ mode, call the `type_text()` and start the script. A new Chrome/Chromium window will now open. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Words mode of your desired length.  
+* *Words* - To let the script perform a typing test in the _words_ mode, call the `type_text()` function at the bottom of the file and start the script. A new Chrome/Chromium window will now open. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Words mode of your desired length.  
   
-*Quote* - To let the script perform a typing test in the _quote_ mode, call the `type_text()` method and start the script. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Quote mode of your desired length.  
+* *Quote* - To let the script perform a typing test in the _quote_ mode, call the `type_text()` function at the bottom of the file method and start the script. A new Chrome/Chromium window will now open. Use the starting delay to switch to the Quote mode of your desired length.  
   
+*Timed tests, 15, 30, 60 and 120 seconds, are not supported*
 
 There are a few options the user can use to modify the execution of the script:  
 
-* Random typing speed. To randomize typing speed, the user can call the `get_random_pause()` function to randomize the pausing time between each character. This allows for a varying speed and consistency. 
-* Given typing speed. To increase or decrease the time between each typed character, the `get_given_pause()` function can be called. The time between each character is the same when using this function. 
-* Sleep time before execution. When one of the typing functions is called, the program wil pause execution. This is done in order to allow the user to open the desired typing mode on MonkeyType.
+* Random typing speed. To randomize typing speed, the user can call the `get_random_pause()` function can be called at the bottom of the file, before calling `type_text()`. This randomizes typing speed and allows for a varying consistency. 
+* Given typing speed. To increase or decrease the time between each typed character, the `get_given_pause()` function can be called at the bottom of the file, before calling `type_text()`. The time between each character is the same when using this function. 
+* Sleep time before execution. When the `type_text()` function is called, the program wil pause execution. This is done in order to allow the user to open the desired typing mode on MonkeyType.
 
 # Demonstrations
 
-Here is an example of the script in action during a custom typing test:  
-https://www.youtube.com/watch?v=FW1lzQ1OVnk
+
+* Custom typing test: https://www.youtube.com/watch?v=FW1lzQ1OVnk

--- a/README.md
+++ b/README.md
@@ -39,4 +39,7 @@ There are a few options the user can use to modify the execution of the script:
 * Given typing speed. To increase or decrease the time between each typed character, the `get_given_pause()` method can be called. The time between each character is the same when using this method. 
 * Sleep time before execution. When one of the typing methods is called, the program wil pause execution. This is done in order to allow the user to open the desired typing mode on MonkeyType.
 
+# Demonstrations
 
+Here is an example of the script in action during a custom typing test:  
+https://www.youtube.com/watch?v=FW1lzQ1OVnk

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requirements:
 * On Ubuntu based distrubutions use `sudo apt-get install chromium-browser`  
 * On other operating systems, go to: https://www.chromium.org/getting-involved/download-chromium
   
-_Make sure to download a Chrome/Chromium version that is compatible with the Chromedriver, you can also replace the Chromedriver with a different version_
+_Make sure to download a Chrome/Chromium version that is compatible with the Chromedriver, you can also replace the Chromedriver in the folder with a different version_
 # How to use  
 Right now this script only supports the following typing modes on MonkeyType:
 
@@ -45,3 +45,4 @@ There are a few options the user can use to modify the execution of the script:
 
 
 * Custom typing test: https://www.youtube.com/watch?v=FW1lzQ1OVnk
+* 100 words with infinite speed: https://www.youtube.com/watch?v=fzWOdUH6yL0

--- a/python-autotyper-script.py
+++ b/python-autotyper-script.py
@@ -2,6 +2,8 @@ import sys
 import time
 import random
 import pyautogui
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium import webdriver
 
 # Generates a random seed for randomizing typing speed and consistency
@@ -12,11 +14,8 @@ random.seed(seedValue)
 browser = webdriver.Chrome(executable_path='chromedriver')
 browser.get('https://monkeytype.com/')
 
-# Enter the text to type inside the double quotes, this is used in the custom text mode on MonkeyType
-text = ""
 
-
-def type_random_text():
+def type_text():
     # Doesn't support timed mode yet (15, 30, 60, 120 seconds)
     # time delay after which script runs after starting the program.
     # This delay allows the user to switch to a typing test mode with a given number of words: 10, 25, 50, 100 words.
@@ -24,22 +23,22 @@ def type_random_text():
     words = browser.find_elements_by_class_name('word')
 
     for word in words:
-        for char in word.get_attribute('textContent'):
-            pyautogui.typewrite(char)
-        # Adds a space after every word typed
-        pyautogui.typewrite(' ')
+        # Using selenium send_keys() to type the word if it contains single or double quotation marks.
+        if "'" in word.get_attribute('textContent') or '"' in word.get_attribute('textContent'):
 
+            # Because 'word' isn't an input element, an ActionChain is used to be able to send keys
+            actions = ActionChains(browser)
+            actions.send_keys(word.get_attribute('textContent') + ' ')
+            actions.perform()
 
-def type_given_text(text_to_type):
-    # time delay after which script runs after starting the program
-    # This is used to allow the user some time to switch to the typing test running in the browser
-    time.sleep(10)
-    char_list = [i for i in text_to_type]
+        # If the word doesn't contain quotation marks, the word is typed character by character.
+        # This is done to be able to make use of the pause_time functions.
+        else:
+            for char in word.get_attribute('textContent'):
+                pyautogui.typewrite(char)
 
-    for char in char_list:
-        # Uncomment line below and insert parameters for randomised typing speed.
-        # get_random_pause()
-        pyautogui.typewrite(char)
+            # Adds a space after every word typed
+            pyautogui.typewrite(' ')
 
 
 def get_random_pause(lower_bound, upper_bound):
@@ -60,4 +59,4 @@ def get_given_pause(pause_time):
 
 
 get_given_pause(3)
-type_random_text()
+type_text()

--- a/python-autotyper-script.py
+++ b/python-autotyper-script.py
@@ -1,14 +1,11 @@
-import pyautogui
+import sys
 import time
 import random
-from datetime import datetime
+import pyautogui
 from selenium import webdriver
-import sys
 
+# Generates a random seed for randomizing typing speed and consistency
 seedValue = random.randrange(sys.maxsize)
-
-# Uses the current time as a seed for randomised typing speed
-# This method is outdated as of Python 3.9, so I have to find a different solution for seeding.
 random.seed(seedValue)
 
 # Opens MonkeyType in a Chromemium/Chrome window

--- a/testing.py
+++ b/testing.py
@@ -1,6 +1,12 @@
 # This file is used to test/experiment with new functionality and potential bug fixes before implementing them in the main file
-from selenium import webdriver
+import sys
 import time
+import random
+import pyautogui
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium import webdriver
+
 
 # Opens MonkeyType in a Chromemium/Chrome window
 browser = webdriver.Chrome(executable_path='chromedriver')
@@ -10,14 +16,11 @@ browser.get('https://monkeytype.com/')
 def find_words():
     words = browser.find_elements_by_class_name('word')
 
-    word_list = []
-
     for word in words:
-        word_list.append(word.get_attribute('textContent'))
-
-    return word_list
+        actions = ActionChains(browser)
+        actions.send_keys(word.get_attribute('textContent') + ' ')
+        actions.perform()
 
 
 time.sleep(10)
-
 find_words()


### PR DESCRIPTION
I updated the documentation and fixed a bug. In my previous pull request the script would be unable to type tests with randomized texts. I added support for randomized texts. The scripts now also supports typing single and double quotation marks that are often found in the _quote_ mode.